### PR TITLE
Fixed ScrollToTop button scrolling issue

### DIFF
--- a/src/Components/ScrollToTop/scrolltotop.component.jsx
+++ b/src/Components/ScrollToTop/scrolltotop.component.jsx
@@ -7,7 +7,7 @@ export default function ScrollToTop() {
     const [isPageScrolled, setIsPageScrolled] = useState(false)
 
     useScrollPosition(({ prevPos, currPos }) => {
-            const isShow = currPos.y < prevPos.y
+            const isShow = currPos.y < prevPos.y || currPos.y !== 0;
             if (isShow !== isPageScrolled) {
                 setIsPageScrolled(isShow)
             }


### PR DESCRIPTION
Now the button will not be displayed only in the case when the user is at the top of the page.